### PR TITLE
Fix some typos

### DIFF
--- a/text/first-layout.md
+++ b/text/first-layout.md
@@ -15,7 +15,7 @@ Which reads approximately as "A List is either Empty or an Element followed by a
 List". This is a recursive definition expressed as a *sum type*, which is a
 fancy name for "a type that can have different values which may be different
 types". Rust calls sum types `enum`s! If you're coming from a C-like language,
-this is exactly the enum you known and love, but on meth. So let's transcribe
+this is exactly the enum you know and love, but on meth. So let's transcribe
 this functional definition into Rust!
 
 For now we'll avoid generics to keep things simple. We'll only support

--- a/text/first-layout.md
+++ b/text/first-layout.md
@@ -124,7 +124,7 @@ Hey it built!
 we're allocating the `Empty` at the end of every list *on the heap*. This is
 a strong sign that we're doing something silly.
 
-So how do we write our List? Well, we could do something like:
+So how do we rewrite our List? Well, we could do something like:
 
 ```rust
 pub enum List {
@@ -202,7 +202,7 @@ pub enum List {
 Let's check our priorities:
 
 * tail of a list never allocates: check!
-* enum is in delicious null-pointer form: check!
+* enum is in delicious null-pointer-optimized form: check!
 
 Alright!
 

--- a/text/first-new.md
+++ b/text/first-new.md
@@ -36,7 +36,7 @@ A few notes on this:
   not repeating yourself!
 * We create an instance of a struct in much the same way we declare it, except
   instead of providing the types of its fields, we initialize them with values.
-* We refer to variants of an enum using `::`, which is the namespacing operator
+* We refer to variants of an enum using `::`, which is the namespacing operator.
 * The last expression of a function is implicitly returned.
   This makes simple functions a little neater. You can still use `return`
   to return early like other C-like languages.

--- a/text/first-ownership.md
+++ b/text/first-ownership.md
@@ -25,9 +25,9 @@ owns the value, and the old location can no longer access it. For this reason
 most methods don't want `self` -- it would be pretty lame if trying to work with
 a list made it go away!
 
-A mutable reference represents temporary *exlusive access* to a value that you
+A mutable reference represents temporary *exclusive access* to a value that you
 don't own. You're allowed to do absolutely anything you want to a value you
-have to a mutable reference as long as when your loan expires, wherever you
+have a mutable reference to as long as when your loan expires, wherever you
 loaned it from still sees a valid value. This means you can actually completely
 overwrite the value. A really useful special case of this is *swapping* a value
 out for another, which we'll be using a lot. The only thing you can't do with an

--- a/text/first-pop.md
+++ b/text/first-pop.md
@@ -189,7 +189,7 @@ Could not compile `lists`.
 
 Now we have two *different* errors. First, we're trying to move out of `node`
 when all we have is a shared reference to it. Second, we're trying to mutate
-`self.head` while we've reborrowed it to get the reference to `node`!
+`self.head` while we've already borrowed it to get the reference to `node`!
 
 This is a tangled mess.
 
@@ -241,7 +241,7 @@ value to return, but actually we didn't need to do that at all! Just as a
 function evaluated to its last expression, every block also evaluates to
 its last expression. Normally we supress this behaviour with semi-colons,
 which instead makes the block evaluate to the empty tuple, `()`. This is
-actually the value that functions that don't declare a return value -- like
+actually the value that functions which don't declare a return value -- like
 `push` -- return.
 
 So instead, we can write `pop` as:
@@ -337,7 +337,7 @@ language that the compiler lets you do some stuff that nothing else can do. We
 actually have been doing one such thing this whole time: `DerefMove`. Whenever
 you have a pointer type you can derefence it with `*` or `.` to get at its
 contents. Usually you can get a `Deref` or maybe even a `DerefMut`,
-corresponding to a shared and mutable references respectively.
+corresponding to a shared or mutable reference respectively.
 
 However because Box totally owns its contents, you can actually *move out of*
 a dereference. This is total magic, because there's no way for any other type

--- a/text/first-pop.md
+++ b/text/first-pop.md
@@ -56,7 +56,7 @@ Whoops, `pop` has to return a value, and we're not doing that yet. We *could*
 return `None`, but in this case it's probably a better idea to return
 `unimplemented!()`, to indicate that we aren't done implementing the function.
 `unimplemented!()` is a macro (`!` indicates a macro) that panics (basically
-just crashes in a controller manner) the program when we get to it.
+just crashes in a controlled manner) the program when we get to it.
 
 ```rust
 pub fn pop(&mut self) -> Option<i32> {
@@ -73,7 +73,7 @@ pub fn pop(&mut self) -> Option<i32> {
 ```
 
 Unconditional panics are an example of a [diverging function][diverging].
-Diverging functions never return to the caller, so they may used in places
+Diverging functions never return to the caller, so they may be used in places
 where a value of any type is expected. Here, `unimplemented!()` is being
 used in place of a value of type `Option<T>`.
 
@@ -241,7 +241,7 @@ value to return, but actually we didn't need to do that at all! Just as a
 function evaluated to its last expression, every block also evaluates to
 its last expression. Normally we supress this behaviour with semi-colons,
 which instead makes the block evaluate to the empty tuple, `()`. This is
-actually the value what functions that don't declare a return value -- like
+actually the value that functions that don't declare a return value -- like
 `push` -- return.
 
 So instead, we can write `pop` as:

--- a/text/first-push.md
+++ b/text/first-push.md
@@ -11,7 +11,7 @@ impl List {
 }
 ```
 
-First thing's first, we need to make a node to store our element in:
+First things first, we need to make a node to store our element in:
 
 ```rust,ignore
     pub fn push(&mut self, elem: i32) {


### PR DESCRIPTION
Hi!

I liked reading this and felt like contributing some proofreading if you don't mind.

Of the things I didn't touch, why "an `&mut`"?