### PR TITLE
Fix broken link to diverging functions

### DIFF
--- a/text/first-pop.md
+++ b/text/first-pop.md
@@ -349,3 +349,4 @@ future.
 
 
 [ownership]: first-ownership.html
+[diverging]: http://doc.rust-lang.org/nightly/book/functions.html#diverging-functions


### PR DESCRIPTION
Spotted a missing link to diverging functions, which I guess should go to the Rust book.

This book is awesome! Thanks for making it :heart: 