### PR TITLE
Code typos, and add missing `pub`s

### DIFF
--- a/text/first-new.md
+++ b/text/first-new.md
@@ -24,7 +24,7 @@ normal function inside an `impl`:
 
 ```rust
 impl List {
-    fn new() -> Self {
+    pub fn new() -> Self {
         List { head: Link::Empty }
     }
 }

--- a/text/first-pop.md
+++ b/text/first-pop.md
@@ -30,7 +30,7 @@ pub fn pop(&mut self) -> Option<i32> {
         Link::Empty => {
             // TODO
         }
-        Link::More(Node) => {
+        Link::More(node) => {
             // TODO
         }
     };

--- a/text/second-into-iter.md
+++ b/text/second-into-iter.md
@@ -39,7 +39,7 @@ just implement IntoIter as a newtype wrapper around List:
 pub struct IntoIter<T>(List<T>);
 
 impl<T> List<T> {
-    fn into_iter(self) -> IntoIter<T> {
+    pub fn into_iter(self) -> IntoIter<T> {
         IntoIter(self)
     }
 }

--- a/text/second-iter.md
+++ b/text/second-iter.md
@@ -291,7 +291,6 @@ how long the data stored within them is guaranteed to be live. This lifetime
 must be as long as the data needs to be alive, and missing the constraint that
 denotes this will cause this error.
 
-```
 // This won't compile because T is not constrained, meaning the data
 // stored in it is not guaranteed to last as long as the reference
 struct Foo<'a, T> {


### PR DESCRIPTION
Thanks for writing this, it's really good. Here are some typo fixes in the code examples I came across. (Also a markdown formatting error.)