### PR TITLE
Add instructions for rustbook build via mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ A mirror of the rustbook code can be found [here](https://github.com/steveklabni
 This requires a nightly version of the Rust compiler, as well as Cargo:
 
 ```sh
-cd <rustbook-dir>
+cd rustbook/
 cargo build --release
 ```
 
-Once built, the binary can be found at `<rustbook-dir>/target/release/`.
+Once built, the binary can be found at `rustbook/target/release/rustbook`.
 
 ---
 
@@ -42,6 +42,6 @@ Now just copy or link rustbook to be somewhere on your path.
 Once you have the rustbook binary, you just need to do:
 
 ```sh
-cd <too-many-lists-dir>
+cd too-many-lists/
 rm -rf book/ && rustbook build text/ book/
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Read the pretty version at http://cglab.ca/~abeinges/blah/too-many-lists/book/
 
 # Building
 
-Building requires an instance of rustbook be set up on your machine. 
+Building requires an instance of rustbook be set up on your machine.
+
 A mirror of the rustbook code can be found [here](https://github.com/steveklabnik/rustbook).
 This requires a nightly version of the Rust compiler, as well as Cargo:
 
@@ -14,9 +15,31 @@ cargo build --release
 ```
 
 Once built, the binary can be found at `<rustbook-dir>/target/release/`.
+
+---
+
+If that doesn't work (#13), rustbook can also be built as part of rustc.
+Here's instructions for
+[building Rust from source](https://github.com/rust-lang/rust/#building-from-source).
+
+However it needs to be a slight deviation from the normal process:
+
+* You should do `./configure --enable-rpath` instead of `./configure`
+* You don't need to `install` (I don't think rustbook will use that -- although
+  maybe I'm wrong and make install will install rustbook too -- happy to be wrong!)
+
+Once built, rustbook will be somewhere deep in the build target
+directories. This is a bit platform-specific, to be honest. On my
+machine it's at `x86_64-apple-darwin/stage2/bin/rustbook`. The
+`x86_64-apple-darwin` bit is the *really* platform specific part,
+where I hope you can guess what your platform will sort of look
+like. On windows you may need to look in stage3.
+
 Now just copy or link rustbook to be somewhere on your path.
 
-Once you have, you just need to do:
+---
+
+Once you have the rustbook binary, you just need to do:
 
 ```sh
 cd <too-many-lists-dir>

--- a/README.md
+++ b/README.md
@@ -5,25 +5,20 @@ Read the pretty version at http://cglab.ca/~abeinges/blah/too-many-lists/book/
 # Building
 
 Building requires an instance of rustbook be set up on your machine. 
-The only way to do this correctly is to [build Rust from source](https://github.com/rust-lang/rust/#building-from-source) 
+A mirror of the rustbook code can be found [here](https://github.com/steveklabnik/rustbook).
+This requires a nightly version of the Rust compiler, as well as Cargo:
 
-However it needs to be a slight deviation from the normal process:
+```sh
+cd <rustbook-dir>
+cargo build --release
+```
 
-* You should do `./configure --enable-rpath` instead of `./configure` 
-* You don't need to `install` (I don't think rustbook will use that -- although 
-  maybe I'm wrong and make install will install rustbook too -- happy to be wrong!)
-
-Once built, rustbook will be somewhere deep in the build target
-directories. This is a bit platform-specific, to be honest. On my
-machine it's at `x86_64-apple-darwin/stage2/bin/rustbook`. The
-`x86_64-apple-darwin` bit is the *really* platform specific part,
-where I hope you can guess what your platform will sort of look
-like. On windows you may need to look in stage3.
-
+Once built, the binary can be found at `<rustbook-dir>/target/bin/rustbook`.
 Now just copy or link rustbook to be somewhere on your path.
 
 Once you have, you just need to do:
 
-```
+```sh
+cd <too-many-lists-dir>
 rm -rf book/ && rustbook build text/ book/
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ cd <rustbook-dir>
 cargo build --release
 ```
 
-Once built, the binary can be found at `<rustbook-dir>/target/bin/rustbook`.
+Once built, the binary can be found at `<rustbook-dir>/target/release/`.
 Now just copy or link rustbook to be somewhere on your path.
 
 Once you have, you just need to do:


### PR DESCRIPTION
Replaces old instructions of compiling rustc from scratch.

Instead of compiling rustc, I've found a [mirror](https://github.com/steveklabnik/rustbook) of the rustbook code.

Both rustbook and the book compile without problems on my Linux box:
Arch Linux x86_64 (kernel 4.1.3-1-ARCH)
rustc 1.3.0-nightly (4dfe7a16c 2015-07-30)
cargo 0.4.0-nightly (e0a82d6 2015-07-29) (built 2015-07-30)

I'm fairly certain most people will want to avoid bootstrapping the entire rustc compiler if the mirror works just as well.