### PR TITLE
Added missing generic parameter to iter constructor function.

### DIFF
--- a/text/second-iter.md
+++ b/text/second-iter.md
@@ -15,7 +15,7 @@ pub struct Iter<T> {
 }
 
 impl<T> List<T> {
-    pub fn iter(&self) -> Iter {
+    pub fn iter(&self) -> Iter<T> {
         Iter { next: self.head.map(|node| &*node) }
     }
 }


### PR DESCRIPTION
Added missing generic parameter to return value of the constructor method. The subsequent error messages now correspond to what is described in the text.